### PR TITLE
Ignore pipe error when invoking in a pipeline

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -247,6 +247,7 @@ pub fn runPrint(
             , .{});
             return error.HandledError;
         },
+        error.BrokenPipe => {},
         else => |e| return e,
     };
 }


### PR DESCRIPTION
This error usually happens when we do something like `xit log --cli | head`:

```
> xit log --cli | head
error: BrokenPipe
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/posix.zig:1278:22: 0x16746dd in write (xit)
            .PIPE => return error.BrokenPipe,
                     ^
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/fs/File.zig:1327:5: 0x1659af7 in write (xit)
    return posix.write(self.handle, bytes);
    ^
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/io.zig:348:13: 0x16548e4 in typeErasedWriteFn (xit)
            return writeFn(ptr.*, bytes);
            ^
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/io/Writer.zig:13:5: 0x16592d8 in write (xit)
    return self.writeFn(self.context, bytes);
    ^
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/io/Writer.zig:19:18: 0x165448b in writeAll (xit)
        index += try self.write(bytes[index..]);
                 ^
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/fmt.zig:1068:9: 0x1659241 in formatBuf__anon_6678 (xit)
        try writer.writeAll(buf);
        ^
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/fmt.zig:658:21: 0x19ec896 in formatType__anon_499513 (xit)
                    return formatBuf(value, options, writer);
                    ^
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/fmt.zig:193:9: 0x19d1574 in format__anon_494235 (xit)
        try formatType(
        ^
/home/tw/d/zig-linux-x86_64-0.14.0/lib/std/io/Writer.zig:24:5: 0x197895d in print__anon_484507 (xit)
    return std.fmt.format(self, format, args);
    ^
/home/tw/code/xit/src/main.zig:490:21: 0x19760ec in runCommand__anon_483163 (xit)
                    try writers.out.print("    {s}\n", .{line});
                    ^
/home/tw/code/xit/src/main.zig:139:17: 0x1979b94 in run__anon_24029 (xit)
                try runCommand(repo_kind, repo_opts_with_ctx, &repo, allocator, cli_cmd, writers);
```