### PR TITLE
Lazy patch generation

### DIFF
--- a/src/merge.zig
+++ b/src/merge.zig
@@ -1559,6 +1559,11 @@ pub fn Merge(comptime repo_kind: rp.RepoKind, comptime repo_opts: rp.RepoOpts(re
                         };
                     }
 
+                    // Lazy patch generation
+                    if (repo_kind == .xit and merge_algo == .patch) {
+                        try writePossiblePatches(repo_kind, repo_opts, state, allocator, &target_oid, &source_oid);
+                    }
+
                     // diff the base ancestor with the target oid
                     var target_diff = tr.TreeDiff(repo_kind, repo_opts).init(arena.allocator());
                     try target_diff.compare(state.readOnly(), &base_oid, &target_oid, null);
@@ -1813,4 +1818,46 @@ pub fn Merge(comptime repo_kind: rp.RepoKind, comptime repo_opts: rp.RepoOpts(re
             self.allocator.destroy(self.arena);
         }
     };
+}
+
+fn writePossiblePatches(
+    comptime repo_kind: rp.RepoKind,
+    comptime repo_opts: rp.RepoOpts(repo_kind),
+    state: rp.Repo(repo_kind, repo_opts).State(.read_write),
+    allocator: std.mem.Allocator,
+    target_oid: *const [hash.hexLen(repo_opts.hash)]u8,
+    source_oid: *const [hash.hexLen(repo_opts.hash)]u8,
+) !void {
+    var patch_writer = try obj.PatchWriter(repo_kind, repo_opts).init(state.readOnly(), allocator);
+    defer patch_writer.deinit(allocator);
+
+    const base_oid = try commonAncestor(repo_kind, repo_opts, allocator, state.readOnly(), target_oid, source_oid);
+    var source_iter = try obj.ObjectIterator(.xit, repo_opts, .full).init(allocator, state.readOnly(), .{ .kind = .commit });
+    defer source_iter.deinit();
+    try source_iter.include(source_oid);
+    while (try source_iter.next()) |commit_object| {
+        defer commit_object.deinit();
+
+        const oid = try hash.hexToBytes(repo_opts.hash, commit_object.oid);
+        try patch_writer.add(state.readOnly(), allocator, &oid);
+
+        if (std.mem.eql(u8, &base_oid, &commit_object.oid)) {
+            break;
+        }
+    }
+    var target_iter = try obj.ObjectIterator(.xit, repo_opts, .full).init(allocator, state.readOnly(), .{ .kind = .commit });
+    defer target_iter.deinit();
+    try target_iter.include(target_oid);
+    while (try target_iter.next()) |commit_object| {
+        defer commit_object.deinit();
+
+        const oid = try hash.hexToBytes(repo_opts.hash, commit_object.oid);
+        try patch_writer.add(state.readOnly(), allocator, &oid);
+
+        if (std.mem.eql(u8, &base_oid, &commit_object.oid)) {
+            break;
+        }
+    }
+
+    try patch_writer.write(state, allocator, null);
 }

--- a/src/repo.zig
+++ b/src/repo.zig
@@ -986,43 +986,7 @@ pub fn Repo(comptime repo_kind: RepoKind, comptime repo_opts: RepoOpts(repo_kind
                         try config.add(state, .{ .name = "merge.algorithm", .value = "patch" });
                     }
 
-                    var obj_iter = try obj.ObjectIterator(repo_kind, repo_opts, .full).init(ctx.allocator, state.readOnly(), .{ .kind = .commit });
-                    defer obj_iter.deinit();
-
-                    // add heads
-                    {
-                        var ref_list = try rf.RefList.init(repo_kind, repo_opts, state.readOnly(), ctx.allocator, .head);
-                        defer ref_list.deinit();
-
-                        for (ref_list.refs.values()) |ref| {
-                            if (try rf.readRecur(repo_kind, repo_opts, state.readOnly(), .{ .ref = ref })) |oid| {
-                                try obj_iter.include(&oid);
-                            }
-                        }
-                    }
-
-                    // add tags
-                    {
-                        var ref_list = try rf.RefList.init(repo_kind, repo_opts, state.readOnly(), ctx.allocator, .tag);
-                        defer ref_list.deinit();
-
-                        for (ref_list.refs.values()) |ref| {
-                            if (try rf.readRecur(repo_kind, repo_opts, state.readOnly(), .{ .ref = ref })) |oid| {
-                                try obj_iter.include(&oid);
-                            }
-                        }
-                    }
-
-                    var patch_writer = try obj.PatchWriter(repo_kind, repo_opts).init(state.readOnly(), ctx.allocator);
-                    defer patch_writer.deinit(ctx.allocator);
-
-                    while (try obj_iter.next()) |commit_object| {
-                        defer commit_object.deinit();
-                        const oid = try hash.hexToBytes(repo_opts.hash, commit_object.oid);
-                        try patch_writer.add(state.readOnly(), ctx.allocator, &oid);
-                    }
-
-                    try patch_writer.write(state, ctx.allocator, ctx.progress_ctx_maybe);
+                    // Patches will be generated when necessary.
                 }
             };
 


### PR DESCRIPTION
Actually we don't need to generate all the patch beforehand, as most of them will never be used.
With this change, we only generate the necessary possible patches when merging.