### PR TITLE
Use smp_allocator in release build

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -10,6 +10,7 @@
 //!  Let this be our first!" -- Lunar: Silver Star Story
 
 const std = @import("std");
+const builtin = @import("builtin");
 const cmd = @import("./command.zig");
 const rp = @import("./repo.zig");
 const ui = @import("./ui.zig");
@@ -686,14 +687,17 @@ fn printMergeResult(
     }
 }
 
+var debug_allocator: std.heap.DebugAllocator(.{}) = .init;
+
 /// this is the main "main". it's even mainier than "run".
 /// this is the real deal. there is no main more main than this.
 /// at least, not that i know of. i guess internally zig probably
 /// has an earlier entrypoint which is even mainier than this.
 pub fn main() !u8 {
-    var gpa: std.heap.DebugAllocator(.{}) = .init;
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
+    const allocator = if (builtin.mode == .Debug) debug_allocator.allocator() else std.heap.smp_allocator;
+    defer if (builtin.mode == .Debug) {
+        _ = debug_allocator.deinit();
+    };
 
     var args = std.ArrayList([]const u8).init(allocator);
     defer args.deinit();


### PR DESCRIPTION
Here's my local benchmark result with release build of xit:

```
Benchmark 1: /home/tw/code/xit/zig-out/bin/xit_old clone ssh://xxx xit_old
  Time (mean ± σ):     10.316 s ±  0.146 s    [User: 4.641 s, System: 5.183 s]
  Range (min … max):   10.221 s … 10.484 s    3 runs

Benchmark 2: /home/tw/code/xit/zig-out/bin/xit_new clone ssh://xxx xit_new
  Time (mean ± σ):      9.055 s ±  0.035 s    [User: 4.504 s, System: 4.144 s]
  Range (min … max):    9.034 s …  9.095 s    3 runs

Summary
  /home/tw/code/xit/zig-out/bin/xit_new clone ssh://xxx xit_new ran
    1.14 ± 0.02 times faster than /home/tw/code/xit/zig-out/bin/xit_old clone ssh://xxx xit_old
```