### PR TITLE
Support fetching specified refs

### DIFF
--- a/src/command.zig
+++ b/src/command.zig
@@ -342,6 +342,8 @@ fn commandHelp(command_kind: CommandKind) Help {
             .example =
             \\fetch from a specific remote:
             \\    xit fetch origin
+            \\fetch from specific refs from remote origin:
+            \\    xit fetch origin refspecs
             ,
         },
         .push => .{
@@ -557,6 +559,7 @@ pub fn Command(comptime repo_kind: rp.RepoKind, comptime hash_kind: hash.HashKin
         },
         fetch: struct {
             remote_name: []const u8,
+            refspec_strs: []const []const u8,
         },
         push: struct {
             remote_name: []const u8,
@@ -885,10 +888,11 @@ pub fn Command(comptime repo_kind: rp.RepoKind, comptime hash_kind: hash.HashKin
                     } };
                 },
                 .fetch => {
-                    if (cmd_args.positional_args.len != 1) return null;
+                    if (cmd_args.positional_args.len < 1) return null;
 
                     return .{ .fetch = .{
                         .remote_name = cmd_args.positional_args[0],
+                        .refspec_strs = if (cmd_args.positional_args.len > 1) cmd_args.positional_args[1..] else &.{},
                     } };
                 },
                 .push => {


### PR DESCRIPTION
The motivation is that I'm using gerrit as a forge and it uses the following git command to fetch change:

```
git fetch origin refs/changes/74/67374/2 && git checkout refs/changes/74/67374/2
```