### PR TITLE
introduce raw ref format

### DIFF
--- a/src/net/refspec.zig
+++ b/src/net/refspec.zig
@@ -198,7 +198,7 @@ pub const RefSpec = struct {
         const dst_ref_maybe = if (rf.Ref.initFromPath(self.dst)) |ref| blk: {
             if (ref.name.len == 0) {
                 break :blk null;
-            } else if (.none == ref.kind) {
+            } else if (.none == ref.kind and !ref.raw) {
                 break :blk rf.Ref{ .kind = .head, .name = ref.name };
             } else {
                 break :blk ref;

--- a/src/ref.zig
+++ b/src/ref.zig
@@ -51,6 +51,7 @@ pub const RefKind = union(enum) {
 pub const Ref = struct {
     kind: RefKind,
     name: []const u8,
+    raw: bool = false,
 
     pub fn initFromPath(ref_path: []const u8) ?Ref {
         var split_iter = std.mem.splitScalar(u8, ref_path, '/');
@@ -79,8 +80,10 @@ pub const Ref = struct {
             const remote_name = split_iter.next() orelse return null;
             const remote_ref_name = ref_name[remote_name.len + 1 ..];
             return .{ .kind = .{ .remote = remote_name }, .name = remote_ref_name };
+        } else if (std.mem.eql(u8, "raw", ref_kind)) {
+            return .{ .kind = .none, .name = ref_name, .raw = true };
         } else {
-            return null;
+            return .{ .kind = .none, .name = ref_path };
         }
     }
 


### PR DESCRIPTION
This change introduces a new ref format: refs/raw/xxx. The motivation behind this is compatibility with gerrit (https://gerrit-review.googlesource.com/Documentation/user-upload.html#push_create).