### PR TITLE
fs: truncate `ino` and `dev`

### DIFF
--- a/src/fs.zig
+++ b/src/fs.zig
@@ -159,8 +159,8 @@ pub const Stat = struct {
             else => {
                 const stat = try std.posix.fstat(fd);
                 return .{
-                    .dev = @intCast(stat.dev),
-                    .ino = @intCast(stat.ino),
+                    .dev = @truncate(stat.dev),
+                    .ino = @truncate(stat.ino),
                     .uid = stat.uid,
                     .gid = stat.gid,
                 };


### PR DESCRIPTION
On some filesystems, `ino` and `dev` are wider than 32 bits, in which case `xit` will crash.

For example: `zig build try` or `zig build test` will crash if it's on a bcachefs filesystem; I imagine also on `btrfs`, and on some `ext4`/`xfs` configurations.

I tested the same exact environment, toolchain etc on a virtual machine just to be sure.

An example of the failure on `zig build try`:

```
$ zig build try

thread 1049 panic: integer does not fit in destination type
/mnt/xit/src/fs.zig:163:28: 0x152a772 in init (try)
                    .ino = @intCast(stat.ino),
                           ^
/mnt/xit/src/fs.zig:204:34: 0x152b348 in init (try)
            fstat = try Stat.init(file.handle);
                                 ^
/mnt/xit/src/workdir.zig:194:46: 0x152d85b in addEntries (try)
            const meta = try fs.Metadata.init(work_dir, path);
                                             ^
/mnt/xit/src/workdir.zig:99:31: 0x15434d4 in init (try)
            _ = try addEntries(allocator, arena, &untracked, &work_dir_modified, &index, &index_bools, state.core.work_dir, ".");
                              ^
/mnt/xit/src/repo.zig:681:62: 0x1545a28 in status (try)
            return try work.Status(repo_kind, repo_opts).init(allocator, state);
                                                             ^
/mnt/xit/src/try.zig:92:41: 0x17711f5 in main (try)
        var status = try git_repo.status(allocator);
                                        ^
/nix/store/wwjxwysa0igp0kjryg6bsnvzq7b0byi1-zig-0.15.1/lib/std/start.zig:627:37: 0x1523db3 in posixCallMainAndExit (try)
            const result = root.main() catch |err| {
                                    ^
/nix/store/wwjxwysa0igp0kjryg6bsnvzq7b0byi1-zig-0.15.1/lib/std/start.zig:232:5: 0x152395d in _start (try)
    asm volatile (switch (native_arch) {
    ^
???:?:?: 0x0 in ??? (???)
try
└─ run exe try failure
error: the following command terminated unexpectedly:
/mnt/xit/zig-out/bin/try

Build Summary: 5/7 steps succeeded; 1 failed
try transitive failure
└─ run exe try failure

error: the following build command failed with exit code 1:
...
```