### PR TITLE
Pass down environment variables through `Io` interface

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -807,7 +807,9 @@ pub fn main(init: std.process.Init) !u8 {
         _ = debug_allocator.deinit();
     };
 
-    var threaded = std.Io.Threaded.init(allocator, .{});
+    var threaded = std.Io.Threaded.init(allocator, .{
+        .environ = init.minimal.environ,
+    });
     defer threaded.deinit();
     const io = threaded.io();
 


### PR DESCRIPTION
# Summary

Right now the application doesn't inherit the user's environment variables, e.g. `$PATH`, which some folks may feel attached to : ). 

So unless `ssh` is in a default path, the application will fail to find it and will emit a `error.FileNotFound`, in my case I'm using the snowflake-ish NixOS, so no `/usr/bin/ssh`.

Solution: 
Pass down environment variables in the `Io` interface to please the `Io` gods and 0.16.0.

# Steps to reproduce
1. Move or rename `ssh` out of the default path
2. Have `ssh` in a 
3. `xit clone git@github.com:xit-vcs/xit.git`
4. Watch it all crash and burn

The crash and burn:
```
error: FileNotFound
/nix/store/dgmangk5aq77km7ff4xm0kkvz6xajn6i-zig-0.16.0/lib/std/Io/Threaded.zig:15104:9: 0x13a6627 in processSpawnPosix (xit)
        return child_err;
        ^
/nix/store/dgmangk5aq77km7ff4xm0kkvz6xajn6i-zig-0.16.0/lib/std/process.zig:443:5: 0x1c53ee1 in spawn (xit)
    return io.vtable.processSpawn(io.userdata, options);
    ^
/home/karll/Workspace/Code/External/xit/src/net/ssh.zig:190:26: 0x14df395 in spawnSsh (xit)
    wire_state.process = try std.process.spawn(wire_state.io, .{
                         ^
/home/karll/Workspace/Code/External/xit/src/net/ssh.zig:78:17: 0x14df4f3 in initMaybe (xit)
                try spawnSsh(wire_state, wire_action, sshpath, wire_state.command);
                ^
/home/karll/Workspace/Code/External/xit/src/net/wire.zig:73:32: 0x14df8fa in initMaybe (xit)
            .ssh => |*ssh| if (try net_ssh.SshStream.initMaybe(ssh, url, wire_action)) |stream| .{ .ssh = stream } else null,
                               ^
/home/karll/Workspace/Code/External/xit/src/net/wire.zig:241:17: 0x14e7e58 in connect (xit)
            if (try WireStream.initMaybe(io, allocator, self.wire_state, url_dupe, action)) |stream| {
                ^
/home/karll/Workspace/Code/External/xit/src/net/transport.zig:66:34: 0x14e88ca in connect (xit)
                .wire => |*wire| try wire.connect(io, allocator, url, direction),
                                 ^
/home/karll/Workspace/Code/External/xit/src/net.zig:384:9: 0x14ea36c in connect__anon_42927 (xit)
        try t.connect(state, io, allocator, url, direction);
        ^
/home/karll/Workspace/Code/External/xit/src/net/clone.zig:123:5: 0x15145a7 in cloneWire__anon_489232 (xit)
    try net.connect(repo_kind, repo_opts, state.readOnly(), io, allocator, &remote_copy, .fetch, transport_opts);
    ^
/home/karll/Workspace/Code/External/xit/src/net.zig:709:34: 0x1514bac in run (xit)
                        .wire => try net_clone.cloneWire(
                                 ^
/home/karll/Workspace/Code/External/xit/zig-pkg/xitdb-0.0.0-EEFkxpHJBABxnXvbX5oyeUufyiwNgOwkH03bayvWeYxw/src/lib.zig:1132:29: 0x1522f28 in readSlotPointer__anon_42428 (xit)
                            return err;
                            ^
/home/karll/Workspace/Code/External/xit/zig-pkg/xitdb-0.0.0-EEFkxpHJBABxnXvbX5oyeUufyiwNgOwkH03bayvWeYxw/src/lib.zig:1114:21: 0x1522d2a in readSlotPointer__anon_42428 (xit)
                    return self.readSlotPointer(write_mode, Ctx, path[1..], next_slot_ptr);
                    ^
/home/karll/Workspace/Code/External/xit/zig-pkg/xitdb-0.0.0-EEFkxpHJBABxnXvbX5oyeUufyiwNgOwkH03bayvWeYxw/src/lib.zig:617:44: 0x15180ae in readSlotPointer__anon_42428 (xit)
                    const final_slot_ptr = try self.readSlotPointer(write_mode, Ctx, path[1..], append_result.slot_ptr);
                                           ^
/home/karll/Workspace/Code/External/xit/zig-pkg/xitdb-0.0.0-EEFkxpHJBABxnXvbX5oyeUufyiwNgOwkH03bayvWeYxw/src/lib.zig:2281:38: 0x1523130 in writePath__anon_42424 (xit)
                    const slot_ptr = try self.db.readSlotPointer(.read_write, Ctx, path, self.slot_ptr);
                                     ^
/home/karll/Workspace/Code/External/xit/zig-pkg/xitdb-0.0.0-EEFkxpHJBABxnXvbX5oyeUufyiwNgOwkH03bayvWeYxw/src/lib.zig:3104:25: 0x1523457 in appendContext__anon_42407 (xit)
                    _ = try self.cursor.writePath(Ctx, &.{
                        ^
/home/karll/Workspace/Code/External/xit/src/net.zig:726:13: 0x1523bd4 in clone__anon_42386 (xit)
            try history.appendContext(
            ^
/home/karll/Workspace/Code/External/xit/src/repo.zig:1472:13: 0x1523d1a in clone (xit)
            return net.clone(repo_kind, repo_opts, io, allocator, url, cwd_path, work_path, opts);
            ^
/home/karll/Workspace/Code/External/xit/src/main.zig:141:28: 0x18bcf5b in run__anon_33001 (xit)
                var repo = try rp.Repo(repo_kind, any_repo_opts.toRepoOpts()).clone(
                           ^
/home/karll/Workspace/Code/External/xit/src/main.zig:305:21: 0x18be966 in runPrint__anon_32989 (xit)
        else => |e| return e,
                    ^
/home/karll/Workspace/Code/External/xit/src/main.zig:833:21: 0x18bf13f in main (xit)
        else => |e| return e,
                    ^
run
└─ run exe xit failure
error: process exited with error code 1
failed command: /home/karll/Workspace/Code/External/xit/zig-out/bin/xit clone ssh://git@github.com:xit-vcs/xit.git 
```
