### PR TITLE
Resolve full path for git commands in testnet

### DIFF
--- a/src/test/net.zig
+++ b/src/test/net.zig
@@ -7,41 +7,6 @@ const work = xit.workdir;
 const hash = xit.hash;
 const net = xit.net;
 
-/// Resolve a command name to its full path by searching `$PATH`,
-/// using a similar approach as std.Io.Threaded.processExecutablePath.
-///
-/// Without this, newly spawned shells may fail to locate the command/executable depending
-/// on the setup as they may not inherit $PATH env var.
-///
-/// NOTE:
-/// - Assumes we are in a testing environment.
-/// - Assumes a gpa--general purpose allocator--so it handles its own
-/// deinitilization.
-fn resolveCommand(gpa: std.mem.Allocator, command: []const u8) ![]const u8 {
-    const io = std.testing.io;
-    const io_instance = std.testing.io_instance;
-
-    var env_map = try std.process.Environ.createMap(io_instance.environ.process_environ, gpa);
-    defer env_map.deinit();
-
-    const path_env = env_map.get("PATH") orelse return error.FileNotFound;
-
-    var it = std.mem.tokenizeScalar(u8, path_env, std.fs.path.delimiter);
-    while (it.next()) |dir| {
-        // skip if directory does not exist
-        const d = std.Io.Dir.openDirAbsolute(io, dir, .{}) catch continue;
-        defer d.close(io);
-
-        // skip if file      does not exist
-        const file = d.openFile(io, command, .{}) catch continue;
-        file.close(io);
-
-        return try std.fs.path.join(gpa, &.{ dir, command });
-    }
-
-    return error.FileNotFound;
-}
-
 test "git fetch small" {
     const io = std.testing.io;
     const allocator = std.testing.allocator;
@@ -292,15 +257,35 @@ fn Server(
                         }
 
                         // create sshd_config file
+                        const sshd_config_str = blk: {
+                            // SetEnv PATH=... allows us to propagate the test process's PATH
+                            // to the spawned login shell (in sshd).
+                            //
+                            // without it, shells that don't auto-resource PATH on startup (e.g. nushell
+                            // on NixOS) through /etc/set-environment will fail to find
+                            // git-upload-pack / git-receive-pack.
+                            const base_config =
+                                \\AuthenticationMethods publickey
+                                \\PubkeyAuthentication yes
+                                \\PasswordAuthentication no
+                                \\StrictModes no
+                                //SetEnv PATH={s} -- if we find $PATH defined.
+                            ;
+                            var env_map = try std.process.Environ.createMap(std.testing.io_instance.environ.process_environ, allocator);
+                            defer env_map.deinit();
+
+                            const config_str = if (env_map.get("PATH")) |path_str|
+                                try std.fmt.allocPrint(allocator, "{s}\n" ++ "SetEnv PATH={s}\n", .{ base_config, path_str })
+                            else
+                                try std.fmt.allocPrint(allocator, "{s}", .{base_config});
+
+                            break :blk config_str;
+                        };
+                        defer allocator.free(sshd_config_str);
+
                         const sshd_config_file = try std.Io.Dir.cwd().createFile(io, temp_dir_name ++ "/sshd_config", .{});
                         defer sshd_config_file.close(io);
-                        try sshd_config_file.writeStreamingAll(io,
-                            \\AuthenticationMethods publickey
-                            \\PubkeyAuthentication yes
-                            \\PasswordAuthentication no
-                            \\StrictModes no
-                            \\
-                        );
+                        try sshd_config_file.writeStreamingAll(io, sshd_config_str);
                         if (.windows != builtin.os.tag) {
                             try sshd_config_file.setPermissions(io, @enumFromInt(0o600));
                         }
@@ -674,7 +659,7 @@ fn testFetch(
 
     const upload_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit upload-pack", .{cwd_path}),
-        .git => resolveCommand(allocator, "git-upload-pack"),
+        .git => allocator.dupe(u8, "git-upload-pack"),
     };
     defer allocator.free(upload_pack_command);
 
@@ -847,12 +832,12 @@ fn testPush(
 
     const upload_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit upload-pack", .{cwd_path}),
-        .git => resolveCommand(allocator, "git-upload-pack"),
+        .git => allocator.dupe(u8, "git-upload-pack"),
     };
     defer allocator.free(upload_pack_command);
     const receive_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit receive-pack", .{cwd_path}),
-        .git => resolveCommand(allocator, "git-receive-pack"),
+        .git => allocator.dupe(u8, "git-receive-pack"),
     };
     defer allocator.free(receive_pack_command);
 
@@ -1126,7 +1111,7 @@ fn testClone(
 
     const upload_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit upload-pack", .{cwd_path}),
-        .git => resolveCommand(allocator, "git-upload-pack"),
+        .git => allocator.dupe(u8, "git-upload-pack"),
     };
     defer allocator.free(upload_pack_command);
 
@@ -1432,7 +1417,7 @@ fn testFetchLarge(
 
     const upload_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit upload-pack", .{cwd_path}),
-        .git => resolveCommand(allocator, "git-upload-pack"),
+        .git => allocator.dupe(u8, "git-upload-pack"),
     };
     defer allocator.free(upload_pack_command);
 
@@ -1671,7 +1656,7 @@ fn testPushLarge(
 
     const receive_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit receive-pack", .{cwd_path}),
-        .git => resolveCommand(allocator, "git-receive-pack"),
+        .git => allocator.dupe(u8, "git-receive-pack"),
     };
     defer allocator.free(receive_pack_command);
 

--- a/src/test/net.zig
+++ b/src/test/net.zig
@@ -7,6 +7,41 @@ const work = xit.workdir;
 const hash = xit.hash;
 const net = xit.net;
 
+/// Resolve a command name to its full path by searching `$PATH`,
+/// using a similar approach as std.Io.Threaded.processExecutablePath.
+///
+/// Without this, newly spawned shells may fail to locate the command/executable depending
+/// on the setup as they may not inherit $PATH env var.
+///
+/// NOTE:
+/// - Assumes we are in a testing environment.
+/// - Assumes a gpa--general purpose allocator--so it handles its own
+/// deinitilization.
+fn resolveCommand(gpa: std.mem.Allocator, command: []const u8) ![]const u8 {
+    const io = std.testing.io;
+    const io_instance = std.testing.io_instance;
+
+    var env_map = try std.process.Environ.createMap(io_instance.environ.process_environ, gpa);
+    defer env_map.deinit();
+
+    const path_env = env_map.get("PATH") orelse return error.FileNotFound;
+
+    var it = std.mem.tokenizeScalar(u8, path_env, std.fs.path.delimiter);
+    while (it.next()) |dir| {
+        // skip if directory does not exist
+        const d = std.Io.Dir.openDirAbsolute(io, dir, .{}) catch continue;
+        defer d.close(io);
+
+        // skip if file      does not exist
+        const file = d.openFile(io, command, .{}) catch continue;
+        file.close(io);
+
+        return try std.fs.path.join(gpa, &.{ dir, command });
+    }
+
+    return error.FileNotFound;
+}
+
 test "git fetch small" {
     const io = std.testing.io;
     const allocator = std.testing.allocator;
@@ -639,7 +674,7 @@ fn testFetch(
 
     const upload_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit upload-pack", .{cwd_path}),
-        .git => allocator.dupe(u8, "git-upload-pack"),
+        .git => resolveCommand(allocator, "git-upload-pack"),
     };
     defer allocator.free(upload_pack_command);
 
@@ -812,12 +847,12 @@ fn testPush(
 
     const upload_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit upload-pack", .{cwd_path}),
-        .git => allocator.dupe(u8, "git-upload-pack"),
+        .git => resolveCommand(allocator, "git-upload-pack"),
     };
     defer allocator.free(upload_pack_command);
     const receive_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit receive-pack", .{cwd_path}),
-        .git => allocator.dupe(u8, "git-receive-pack"),
+        .git => resolveCommand(allocator, "git-receive-pack"),
     };
     defer allocator.free(receive_pack_command);
 
@@ -1091,7 +1126,7 @@ fn testClone(
 
     const upload_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit upload-pack", .{cwd_path}),
-        .git => allocator.dupe(u8, "git-upload-pack"),
+        .git => resolveCommand(allocator, "git-upload-pack"),
     };
     defer allocator.free(upload_pack_command);
 
@@ -1397,7 +1432,7 @@ fn testFetchLarge(
 
     const upload_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit upload-pack", .{cwd_path}),
-        .git => allocator.dupe(u8, "git-upload-pack"),
+        .git => resolveCommand(allocator, "git-upload-pack"),
     };
     defer allocator.free(upload_pack_command);
 
@@ -1636,7 +1671,7 @@ fn testPushLarge(
 
     const receive_pack_command = try switch (server_repo_kind) {
         .xit => std.fmt.allocPrint(allocator, "{s}/zig-out/bin/xit receive-pack", .{cwd_path}),
-        .git => allocator.dupe(u8, "git-receive-pack"),
+        .git => resolveCommand(allocator, "git-receive-pack"),
     };
     defer allocator.free(receive_pack_command);
 


### PR DESCRIPTION
# Summary

Similar issue to https://github.com/xit-vcs/xit/pull/43 

When running `zig build testnet` at some point downstream there is what I assume a new shell which doesn't inherit the path from the current shell.  I don't know if there would be a more proper way to handle this downstream, but it seems safe to me to resolve the path fully in the test, and the `xit` path already resolves to fullpath.

Solution: 
Resolve the commands in testnet to their fullpath before passing it down.

# Steps to reproduce
1. Don't have `git-upload-pack` in your default path (e.g. NixOS)
2. Run `zig build testnet`

The log will roughly look something like this:
```
❯ zig build --summary all testnet
testnet
└─ run test 7 pass, 5 fail (12 total)
error: 'test.net.test.git fetch small' failed:
       /nix/store/dgmangk5aq77km7ff4xm0kkvz6xajn6i-zig-0.16.0/lib/std/Io/File.zig:475:5: 0x10da1d6 in readStreaming (std.zig)
           return (try io.operate(.{ .file_read_streaming = .{
           ^
       /home/khskarl/Workspace/Code/External/xit/src/net/ssh.zig:94:16: 0x18ca938 in read (lib.zig)
               return try stdout.readStreaming(self.wire_state.io, &.{buffer[0..buf_size]});
                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:86:28: 0x18cad43 in read (lib.zig)
                   .ssh => |*ssh| try ssh.read(buffer, buf_size),
                                  ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:602:32: 0x18cb070 in recv (lib.zig)
                   const bytes_read = try wire_stream.read(allocator, self.buffer.offset(), self.buffer.remain());
                                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:656:35: 0x18cbafb in addRefs (lib.zig)
                           const recvd = try self.recv(allocator);
                                         ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:246:13: 0x18ce338 in connect (lib.zig)
                   try self.addRefs(allocator, if (self.is_stateless) 2 else 1);
                   ^
       /home/khskarl/Workspace/Code/External/xit/src/net/transport.zig:66:34: 0x18cf3ab in connect (lib.zig)
                       .wire => |*wire| try wire.connect(io, allocator, url, direction),
                                        ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:384:9: 0x18d1985 in connect__anon_406506 (lib.zig)
               try t.connect(state, io, allocator, url, direction);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:544:9: 0x19fbbca in fetch__anon_854303 (lib.zig)
               try connect(repo_kind, repo_opts, state.readOnly(), io, allocator, remote, .fetch, transport_opts);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/repo.zig:1487:21: 0x19fd03f in fetch (lib.zig)
                           try net.fetch(repo_kind, repo_opts, state, io, allocator, &remote, opts);
                           ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:646:5: 0x1dad955 in testFetch__anon_864473 (testnet.zig)
           try client_repo.fetch(
           ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:16:9: 0x1dbb4e0 in test.git fetch small (testnet.zig)
               try testFetch(.git, .git, .{ .wire = .ssh }, 3003, io, allocator);
               ^
error: 'test.net.test.git push small' failed:
       /nix/store/dgmangk5aq77km7ff4xm0kkvz6xajn6i-zig-0.16.0/lib/std/Io/File.zig:475:5: 0x10da1d6 in readStreaming (std.zig)
           return (try io.operate(.{ .file_read_streaming = .{
           ^
       /home/khskarl/Workspace/Code/External/xit/src/net/ssh.zig:94:16: 0x18ca938 in read (lib.zig)
               return try stdout.readStreaming(self.wire_state.io, &.{buffer[0..buf_size]});
                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:86:28: 0x18cad43 in read (lib.zig)
                   .ssh => |*ssh| try ssh.read(buffer, buf_size),
                                  ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:602:32: 0x18cb070 in recv (lib.zig)
                   const bytes_read = try wire_stream.read(allocator, self.buffer.offset(), self.buffer.remain());
                                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:656:35: 0x18cbafb in addRefs (lib.zig)
                           const recvd = try self.recv(allocator);
                                         ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:246:13: 0x18ce338 in connect (lib.zig)
                   try self.addRefs(allocator, if (self.is_stateless) 2 else 1);
                   ^
       /home/khskarl/Workspace/Code/External/xit/src/net/transport.zig:66:34: 0x18cf3ab in connect (lib.zig)
                       .wire => |*wire| try wire.connect(io, allocator, url, direction),
                                        ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:384:9: 0x18d1985 in connect__anon_406506 (lib.zig)
               try t.connect(state, io, allocator, url, direction);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:595:9: 0x18e6806 in push__anon_406489 (lib.zig)
               try connect(repo_kind, repo_opts, state, io, allocator, remote, .push, transport_opts);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/repo.zig:1554:13: 0x18e7b84 in push (lib.zig)
                   try net.push(repo_kind, repo_opts, state, io, allocator, &remote, new_opts);
                   ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:824:5: 0x1d42f8a in testPush__anon_863727 (testnet.zig)
           try client_repo.push(
           ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:38:9: 0x1d57920 in test.git push small (testnet.zig)
               try testPush(.git, .git, .{ .wire = .ssh }, 3009, io, allocator);
               ^
error: 'test.net.test.git clone small' failed:
       /nix/store/dgmangk5aq77km7ff4xm0kkvz6xajn6i-zig-0.16.0/lib/std/Io/File.zig:475:5: 0x10da1d6 in readStreaming (std.zig)
           return (try io.operate(.{ .file_read_streaming = .{
           ^
       /home/khskarl/Workspace/Code/External/xit/src/net/ssh.zig:94:16: 0x18ca938 in read (lib.zig)
               return try stdout.readStreaming(self.wire_state.io, &.{buffer[0..buf_size]});
                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:86:28: 0x18cad43 in read (lib.zig)
                   .ssh => |*ssh| try ssh.read(buffer, buf_size),
                                  ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:602:32: 0x18cb070 in recv (lib.zig)
                   const bytes_read = try wire_stream.read(allocator, self.buffer.offset(), self.buffer.remain());
                                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:656:35: 0x18cbafb in addRefs (lib.zig)
                           const recvd = try self.recv(allocator);
                                         ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:246:13: 0x18ce338 in connect (lib.zig)
                   try self.addRefs(allocator, if (self.is_stateless) 2 else 1);
                   ^
       /home/khskarl/Workspace/Code/External/xit/src/net/transport.zig:66:34: 0x18cf3ab in connect (lib.zig)
                       .wire => |*wire| try wire.connect(io, allocator, url, direction),
                                        ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:384:9: 0x18d1985 in connect__anon_406506 (lib.zig)
               try t.connect(state, io, allocator, url, direction);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/net/clone.zig:123:5: 0x1c51118 in cloneWire__anon_861828 (lib.zig)
           try net.connect(repo_kind, repo_opts, state.readOnly(), io, allocator, &remote_copy, .fetch, transport_opts);
           ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:672:26: 0x1c51cdb in clone__anon_861685 (lib.zig)
                       .wire => try net_clone.cloneWire(
                                ^
       /home/khskarl/Workspace/Code/External/xit/src/repo.zig:1472:13: 0x1c52260 in clone (lib.zig)
                   return net.clone(repo_kind, repo_opts, io, allocator, url, cwd_path, work_path, opts);
                   ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:1276:27: 0x1c63b2c in testClone__anon_861928 (testnet.zig)
               var client_repo = try rp.Repo(repo_kind, .{ .is_test = true }).clone(
                                 ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:60:9: 0x1c6a9f0 in test.git clone small (testnet.zig)
               try testClone(.git, .git, .{ .wire = .ssh }, 3015, false, io, allocator);
               ^
error: 'test.net.test.git fetch large' failed:
       /nix/store/dgmangk5aq77km7ff4xm0kkvz6xajn6i-zig-0.16.0/lib/std/Io/File.zig:475:5: 0x10da1d6 in readStreaming (std.zig)
           return (try io.operate(.{ .file_read_streaming = .{
           ^
       /home/khskarl/Workspace/Code/External/xit/src/net/ssh.zig:94:16: 0x18ca938 in read (lib.zig)
               return try stdout.readStreaming(self.wire_state.io, &.{buffer[0..buf_size]});
                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:86:28: 0x18cad43 in read (lib.zig)
                   .ssh => |*ssh| try ssh.read(buffer, buf_size),
                                  ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:602:32: 0x18cb070 in recv (lib.zig)
                   const bytes_read = try wire_stream.read(allocator, self.buffer.offset(), self.buffer.remain());
                                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:656:35: 0x18cbafb in addRefs (lib.zig)
                           const recvd = try self.recv(allocator);
                                         ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:246:13: 0x18ce338 in connect (lib.zig)
                   try self.addRefs(allocator, if (self.is_stateless) 2 else 1);
                   ^
       /home/khskarl/Workspace/Code/External/xit/src/net/transport.zig:66:34: 0x18cf3ab in connect (lib.zig)
                       .wire => |*wire| try wire.connect(io, allocator, url, direction),
                                        ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:384:9: 0x18d1985 in connect__anon_406506 (lib.zig)
               try t.connect(state, io, allocator, url, direction);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:544:9: 0x19fbbca in fetch__anon_854303 (lib.zig)
               try connect(repo_kind, repo_opts, state.readOnly(), io, allocator, remote, .fetch, transport_opts);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/repo.zig:1487:21: 0x19fd03f in fetch (lib.zig)
                           try net.fetch(repo_kind, repo_opts, state, io, allocator, &remote, opts);
                           ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:1481:9: 0x1a0dea1 in testFetchLarge__anon_854908 (testnet.zig)
               try client_repo.fetch(
               ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:92:9: 0x1a14680 in test.git fetch large (testnet.zig)
               try testFetchLarge(.git, .git, .{ .wire = .ssh }, 3021, false, io, allocator);
               ^
error: 'test.net.test.git push large' failed:
       /nix/store/dgmangk5aq77km7ff4xm0kkvz6xajn6i-zig-0.16.0/lib/std/Io/File.zig:475:5: 0x10da1d6 in readStreaming (std.zig)
           return (try io.operate(.{ .file_read_streaming = .{
           ^
       /home/khskarl/Workspace/Code/External/xit/src/net/ssh.zig:94:16: 0x18ca938 in read (lib.zig)
               return try stdout.readStreaming(self.wire_state.io, &.{buffer[0..buf_size]});
                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:86:28: 0x18cad43 in read (lib.zig)
                   .ssh => |*ssh| try ssh.read(buffer, buf_size),
                                  ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:602:32: 0x18cb070 in recv (lib.zig)
                   const bytes_read = try wire_stream.read(allocator, self.buffer.offset(), self.buffer.remain());
                                      ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:656:35: 0x18cbafb in addRefs (lib.zig)
                           const recvd = try self.recv(allocator);
                                         ^
       /home/khskarl/Workspace/Code/External/xit/src/net/wire.zig:246:13: 0x18ce338 in connect (lib.zig)
                   try self.addRefs(allocator, if (self.is_stateless) 2 else 1);
                   ^
       /home/khskarl/Workspace/Code/External/xit/src/net/transport.zig:66:34: 0x18cf3ab in connect (lib.zig)
                       .wire => |*wire| try wire.connect(io, allocator, url, direction),
                                        ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:384:9: 0x18d1985 in connect__anon_406506 (lib.zig)
               try t.connect(state, io, allocator, url, direction);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/net.zig:595:9: 0x18e6806 in push__anon_406489 (lib.zig)
               try connect(repo_kind, repo_opts, state, io, allocator, remote, .push, transport_opts);
               ^
       /home/khskarl/Workspace/Code/External/xit/src/repo.zig:1554:13: 0x18e7b84 in push (lib.zig)
                   try net.push(repo_kind, repo_opts, state, io, allocator, &remote, new_opts);
                   ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:1676:9: 0x18ffed5 in testPushLarge__anon_408985 (testnet.zig)
               try client_repo.push(
               ^
       /home/khskarl/Workspace/Code/External/xit/src/test/net.zig:113:9: 0x190d770 in test.git push large (testnet.zig)
               try testPushLarge(.git, .git, .{ .wire = .ssh }, 3027, false, io, allocator);
               ^
failed command: ./.zig-cache/o/7bbdd3e027982cd12bd7c509be2e447e/test --cache-dir=./.zig-cache --seed=0x5a8525b2 --listen=-

Build Summary: 3/5 steps succeeded (1 failed); 7/12 tests passed (5 failed)
testnet transitive failure
├─ install xit cached
│  └─ compile exe xit Debug native cached 8ms MaxRSS:40M
└─ run test 7 pass, 5 fail (12 total)
   └─ compile test Debug native success 4s MaxRSS:306M
```
